### PR TITLE
Accept public connection

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,4 +6,4 @@ def hello_world():
     return 'Hello, World!'
 
 if __name__ == "__main__":
-    app.run(host='127.0.0.1', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
For running on a public IP, e.g. EC2 instance, and accepting a connection, the host should be `0.0.0.0`. When the host is `127.0.01` (localhost) we can't access it via the EC2 public address even if we open the port in its Security Group.